### PR TITLE
Add event date to page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="img/favicon-blue.png" />
-  <title>hackMHS II</title>
+  <title>hackMHS II | May 21-22</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <link href="css/main.css" rel="stylesheet">


### PR DESCRIPTION
You can do everyone a HUGE favor by putting dates in your homepage < title > tag. There are a handful of times where people end up visiting hackathon sites just to double-check when an event is happening. 

Feel free to implement this however you want, my PR is just a suggestion.

![image](https://cloud.githubusercontent.com/assets/607807/14770804/19cb80ce-0a48-11e6-8d1f-ce2a1fb41360.png)
